### PR TITLE
Create dir before trying to copy a file to it

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,13 +16,14 @@ PKI_DB_DIR="$PKI_DIR/db"
 
 #if $PKI_DB_DIR is empty, bootstrap $PKI_DB_DIR
 if [ ! -d "$PKI_DB_DIR" ]; then
+
+  make-cadir $PKI_DB_DIR
+
   #load in vars file from volume if exists
   if [ -e "$PKI_DIR/vars" ]; then
     cp $PKI_DIR/vars $PKI_DB_DIR/vars
     rm $PKI_DIR/vars
   fi
-
-  make-cadir $PKI_DB_DIR
 
   cd "$PKI_DB_DIR"
   source "$PKI_DB_DIR/vars" &> /dev/null


### PR DESCRIPTION
The scripts tries to copy the file before creating the dir
```
$ docker run --rm -it -v /tmp/pki:/pki tonymke/easy-rsa build-ca
cp: cannot create regular file '/pki/db/vars': No such file or directory
```